### PR TITLE
Update aws-console-redactor.user.js

### DIFF
--- a/aws-console-redactor.user.js
+++ b/aws-console-redactor.user.js
@@ -24,12 +24,8 @@ watchForElements(queryAccountId, "accountId", function (element) {
   redactPattern("arn:aws"); // Redact all ARNs
   redactPattern("Account:"); // Redact trusted accounts on IAM roles list view
   
-  try {
-        const accInheader = accountId.substring(0,4) + "-" + accountId.substring(4,8) + "-" + accountId.substring(8);
-        redactPattern(accInheader); // the banner, where account number is hyphenated 1234-5678-9876 format
-  } catch (e) {
-      console.log(e);
-  }
+  const accInheader = accountId.substring(0,4) + "-" + accountId.substring(4,8) + "-" + accountId.substring(8);
+  redactPattern(accInheader); // the banner, where account number is hyphenated 1234-5678-9876 format
   
 });
 
@@ -80,11 +76,11 @@ function replaceByRedactedLink(node) {
  */
 function copyToClipboard(data) {
   
-  setTimeout(async()=>
+  (async()=>
   {
       await navigator.clipboard.writeText(data.trim());
       alert("Copied to clipboard!");
-  }, 500);
+  })();
   
   // Fixed error regarding document not in focus.
 }

--- a/aws-console-redactor.user.js
+++ b/aws-console-redactor.user.js
@@ -23,6 +23,14 @@ watchForElements(queryAccountId, "accountId", function (element) {
   redactPattern(accountId); // Redact by account ID
   redactPattern("arn:aws"); // Redact all ARNs
   redactPattern("Account:"); // Redact trusted accounts on IAM roles list view
+  
+  try {
+        const accInheader = accountId.substring(0,4) + "-" + accountId.substring(4,8) + "-" + accountId.substring(8);
+        redactPattern(accInheader); // the banner, where account number is hyphenated 1234-5678-9876 format
+  } catch (e) {
+      console.log(e);
+  }
+  
 });
 
 /**
@@ -71,8 +79,14 @@ function replaceByRedactedLink(node) {
  * Copy "data" to clipboard
  */
 function copyToClipboard(data) {
-  navigator.clipboard.writeText(data.trim());
-  alert("Copied to clipboard!");
+  
+  setTimeout(async()=>
+  {
+      await navigator.clipboard.writeText(data.trim());
+      alert("Copied to clipboard!");
+  }, 500);
+  
+  // Fixed error regarding document not in focus.
 }
 
 /**


### PR DESCRIPTION
Two fixes are made: 
* Click to copy now works
* Hides the account number in the banner

![image](https://user-images.githubusercontent.com/25214445/131586560-aa7ef9d1-9f4a-43e7-a544-274a1bd04f3b.png)
